### PR TITLE
Fix MissingForegroundServiceTypeException in MyRadioService.java to Resolve Crashing Issue #12

### DIFF
--- a/android/app/src/main/java/com/zindolla/radioamoris/MyRadioService.java
+++ b/android/app/src/main/java/com/zindolla/radioamoris/MyRadioService.java
@@ -203,6 +203,7 @@ public class MyRadioService extends Service {
                 .setContentText(tuneName)
                 .setContentIntent(showAppIntentPending)
                 .setStyle(style);
+                .setForegroundServiceType(NotificationCompat.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK);
 
         Bitmap bm = null;
         if(tuneLogo != null && tuneLogo.length() > 10) {

--- a/android/app/src/main/java/com/zindolla/radioamoris/MyRadioService.java
+++ b/android/app/src/main/java/com/zindolla/radioamoris/MyRadioService.java
@@ -202,7 +202,7 @@ public class MyRadioService extends Service {
                 .setContentTitle("Radio Amoris")
                 .setContentText(tuneName)
                 .setContentIntent(showAppIntentPending)
-                .setStyle(style);
+                .setStyle(style)
                 .setForegroundServiceType(NotificationCompat.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK);
 
         Bitmap bm = null;


### PR DESCRIPTION
This single addition of .setForegroundServiceType(NotificationCompat.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK) tells the Android system that the service is a media playback service, which is essential when the service is intended to perform operations that should be noticeable by the user at all times (like playing audio). This change will ensure compliance with Android's foreground service requirements and prevent the app from crashing due to missing service type specifications.